### PR TITLE
ci: Increase actions/upload-artifact to v7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
 
       - run: cargo build --release
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: zniff-rs-ubuntu
           path: |
@@ -49,7 +49,7 @@ jobs:
 
       - run: cargo build --release
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: zniff-rs-ubuntu-arm
           path: |
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v5
       - run: cargo build --release
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: zniff-rs-windows
           path: |
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@v5
       - run: cargo build --release
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: zniff-rs-macos
           path: |


### PR DESCRIPTION
The increase is required because Node.js 20 actions are deprecated.